### PR TITLE
Use a more specific regex for css replacement

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,6 @@ var babelJest = require('babel-jest');
 module.exports = {
 	process: function(src, filename) {
 		return babelJest.process(src, filename)
-				.replace(/require\(\s*\'.*\.(css|scss|less)\'\);/gm, '');
+				.replace(/require\(\s*\'[a-zA-Z0-9\/\.\-\!]*\.(css|scss|less)\'\);/gm, '');
 	}
 };


### PR DESCRIPTION
For reasons I don't understand, babel will occasionally transform code like:

``` javascript
require('myComponent.css');

import React from 'react';

class MyComponent extends React.Component {
...
}

export default MyComponent;
```

into code like:

``` javascript
...
var _react = require('react');require('myComponent.css'); var
MyComponent = 
...
```

After the replacement is run, the code looks like this:

``` javascript
...
var _react = var
MyComponent = 
...
```

Jest then throws the error `Unknown token var`.

The regex used to replace the CSS require is far too greedy. `[a-zA-Z0-9\/\.\-\!]*` can be used instead `.*` so that only valid file path characters are matched.
